### PR TITLE
#40 Criar contas de usuário com privilégios administrativos

### DIFF
--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -2,29 +2,29 @@ on: [push, pull_request]
 
 name: SonarCloud
 jobs:
-  sonarcloud:
-    runs-on: ubuntu-latest
-    env:
-      DATABASE_URL: postgres://oraculo:oraculo123@localhost:5432/oraculo
-      DB_HOST: localhost
-      DB_PORT: 5432
-    steps:
-      - uses: actions/checkout@v2
-        with:
-          # Disabling shallow clone is recommended for improving relevancy of reporting
-          fetch-depth: 0
-      - name: Run tests
-        uses: actions/setup-node@v1
-        with:
-          node-version: ${{ matrix.node-version }}
-      - run: docker-compose up -d --build
-      - run: npm install
-      - run: npx sequelize-cli db:migrate --config src/Database/config/config.json
-      - run: docker container rm -f oraculo-profiles
-      - run: npx jest --coverage --forceExit
-
-      - name: SonarCloud Scan
-        uses: sonarsource/sonarcloud-github-action@master
+    sonarcloud:
+        runs-on: ubuntu-latest
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+            DATABASE_URL: postgres://oraculo:oraculo123@localhost:5432/oraculo
+            DB_HOST: localhost
+            DB_PORT: 5432
+        steps:
+            - uses: actions/checkout@v2
+              with:
+                  # Disabling shallow clone is recommended for improving relevancy of reporting
+                  fetch-depth: 0
+            - name: Run tests
+              uses: actions/setup-node@v1
+              with:
+                  node-version: ${{ matrix.node-version }}
+            - run: docker-compose up -d --build banco
+            - run: npm install
+            - run: npx sequelize-cli db:migrate --config src/Database/config/config.json
+            - run: node tests/create-admin.js
+            - run: npx jest --coverage --forceExit
+
+            - name: SonarCloud Scan
+              uses: sonarsource/sonarcloud-github-action@master
+              env:
+                  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+                  SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}

--- a/package.json
+++ b/package.json
@@ -1,46 +1,47 @@
 {
-  "name": "2021.1-oraculo-profile",
-  "version": "1.0.0",
-  "description": "",
-  "main": "src/index.js",
-  "scripts": {
-    "test": "jest --coverage",
-    "start": "node src/index.js"
-  },
-  "repository": {
-    "type": "git",
-    "url": "https://github.com/fga-eps-mds/2021.1-Oraculo-Profile.git"
-  },
-  "author": "",
-  "license": "ISC",
-  "bugs": {
-    "url": "https://github.com/fga-eps-mds/2021.1-Oraculo-Profile/issues"
-  },
-  "homepage": "https://github.com/fga-eps-mds/2021.1-Oraculo-Profile#readme",
-  "devDependencies": {
-    "jest": "^27.1.1",
-    "jest-sonar-reporter": "^2.0.0",
-    "supertest": "^6.1.6"
-  },
-  "dependencies": {
-    "bcrypt": "^5.0.1",
-    "bcryptjs": "^2.4.3",
-    "cors": "^2.8.5",
-    "dotenv": "^10.0.0",
-    "express": "^4.17.1",
-    "jsonwebtoken": "^8.5.1",
-    "morgan": "^1.10.0",
-    "pg": "^8.7.1",
-    "sequelize": "^6.6.5",
-    "sequelize-cli": "^6.2.0"
-  },
-  "jest": {
-    "testEnvironment": "node",
-    "collectCoverage": true,
-    "testResultsProcessor": "jest-sonar-reporter",
-    "coveragePathIgnorePatterns": [
-      "/node_modules/",
-      "/test/"
-    ]
-  }
+    "name": "2021.1-oraculo-profile",
+    "version": "1.0.0",
+    "description": "",
+    "main": "src/index.js",
+    "scripts": {
+        "test": "jest --coverage",
+        "start": "node src/index.js"
+    },
+    "repository": {
+        "type": "git",
+        "url": "https://github.com/fga-eps-mds/2021.1-Oraculo-Profile.git"
+    },
+    "author": "",
+    "license": "ISC",
+    "bugs": {
+        "url": "https://github.com/fga-eps-mds/2021.1-Oraculo-Profile/issues"
+    },
+    "homepage": "https://github.com/fga-eps-mds/2021.1-Oraculo-Profile#readme",
+    "devDependencies": {
+        "jest": "^27.1.1",
+        "jest-sonar-reporter": "^2.0.0",
+        "supertest": "^6.1.6"
+    },
+    "dependencies": {
+        "bcrypt": "^5.0.1",
+        "bcryptjs": "^2.4.3",
+        "cors": "^2.8.5",
+        "dotenv": "^10.0.0",
+        "express": "^4.17.1",
+        "jsonwebtoken": "^8.5.1",
+        "morgan": "^1.10.0",
+        "pg": "^8.7.1",
+        "sequelize": "^6.6.5",
+        "sequelize-cli": "^6.2.0"
+    },
+    "jest": {
+        "testEnvironment": "node",
+        "collectCoverage": true,
+        "testResultsProcessor": "jest-sonar-reporter",
+        "coveragePathIgnorePatterns": [
+            "/node_modules/",
+            "/test/",
+            "tests/create-admin.js"
+        ]
+    }
 }

--- a/prepare.sh
+++ b/prepare.sh
@@ -1,0 +1,3 @@
+export DB_HOST=localhost
+export DATABASE_URL=postgres://oraculo:oraculo123@localhost:5432/oraculo
+npx sequelize-cli db:migrate --config src/Database/config/config.json

--- a/src/Controller/UserController.js
+++ b/src/Controller/UserController.js
@@ -7,148 +7,149 @@ const bcrypt = require("bcrypt");
 const jwt = require("jsonwebtoken");
 
 const privilegeTypes = {
-	admin: 1,
-	common: 2,
+    admin: 1,
+    common: 2,
 };
 
 async function findUserLevelByID(req) {
-	const user = await User.findByPk(req.decoded.user_id, {
-		include: {
-			association: "levels",
-		},
-		where: { email: req.decoded.email },
-	});
+    const user = await User.findByPk(req.decoded.user_id, {
+        include: {
+            association: "levels",
+        },
+        where: { email: req.decoded.email },
+    });
 
-	const level = await user.levels[0];
+    const level = await user.levels[0];
 
-	return level;
+    return level;
 }
 
 async function createUser(req, res) {
-	if (
-		!req.body.password ||
-		!req.body.email ||
-		!req.body.departmentID ||
-		!req.body.level ||
-		!req.body.sectionID
-	) {
-		return res.status(400).send({
-			error: "lacks of information to register user",
-		});
-	}
+    if (
+        !req.body.password ||
+        !req.body.email ||
+        !req.body.departmentID ||
+        !req.body.level ||
+        !req.body.sectionID
+    ) {
+        return res.status(400).send({
+            error: "lacks of information to register user",
+        });
+    }
 
-	try {
-		const rawPassword = req.body.password;
+    try {
+        const rawPassword = req.body.password;
 
-		// check for user permission
-		const requesterLevel = await findUserLevelByID(req);
+        // check for user permission
+        const requesterLevel = await findUserLevelByID(req);
 
-		if (requesterLevel.id != privilegeTypes.admin) {
-			return res
-				.status(401)
-				.json({ error: "you do not have privileges to create a user" });
-		}
+        if (requesterLevel.id != privilegeTypes.admin) {
+            return res
+                .status(401)
+                .json({ error: "you do not have privileges to create a user" });
+        }
 
-		const newUserInfo = {
-			permission: req.body.permission,
-			password: await hashPassword(rawPassword),
-			email: req.body.email,
-			departmentID: req.body.departmentID,
-			levelID: req.body.level,
-			sectionID: req.body.sectionID,
-		};
+        const newUserInfo = {
+            password: await hashPassword(rawPassword),
+            email: req.body.email,
+            departmentID: req.body.departmentID,
+            levelID: req.body.level,
+            sectionID: req.body.sectionID,
+        };
 
-		// Search for user department and level
-		const department = await Department.findOne({
-			where: { id: newUserInfo.departmentID },
-		});
+        // Search for user department and level
+        const department = await Department.findOne({
+            where: { id: newUserInfo.departmentID },
+        });
 
-		const level = await Level.findOne({
-			where: { id: newUserInfo.levelID },
-		});
+        const level = await Level.findOne({
+            where: { id: newUserInfo.levelID },
+        });
 
-		const section = await Section.findOne({ where: { id: newUserInfo.sectionID } });
-		if (!department || !level || !section) {
-			return res.status(401).send({ error: "invalid user information provided" });
-		}
+        const section = await Section.findOne({ where: { id: newUserInfo.sectionID } });
+        if (!department || !level || !section) {
+            return res.status(401).send({ error: "invalid user information provided" });
+        }
 
-		const newUser = await User.create({
-			email: newUserInfo.email,
-			password: newUserInfo.password,
-		});
+        const newUser = await User.create({
+            email: newUserInfo.email,
+            password: newUserInfo.password,
+        });
 
-		if (!newUser) {
-			return res.status(500).send({ error: "could not insert user" });
-		}
+        if (!newUser) {
+            return res.status(500).send({ error: "could not insert user" });
+        }
 
-		await newUser.addDepartment(department);
-		await newUser.addLevel(level);
-		await newUser.addSection(section);
+        await newUser.addDepartment(department);
+        await newUser.addLevel(level);
+        await newUser.addSection(section);
 
-		return res.status(200).send(newUser);
-	} catch (error) {
-		console.error(`failed to create user: ${error}`);
-		return res.status(500).json({ error: "internal error during user register" });
-	}
+        return res.status(200).send(newUser);
+    } catch (error) {
+        console.error(`failed to create user: ${error}`);
+        return res.status(500).json({ error: "internal error during user register" });
+    }
 }
 
 async function loginUser(req, res) {
-	try {
-		const { email, password } = req.body;
+    try {
+        const { email, password } = req.body;
 
-		if (!email || !password) {
-			return res.status(400).json({ error: "missing login information" });
-		}
+        if (!email || !password) {
+            return res.status(400).json({ error: "missing login information" });
+        }
 
-		const user = await User.findOne({ where: { email: email } });
+        const user = await User.findOne({ where: { email: email } });
 
-		if (user == null) {
-			return res.status(401).json({ error: "invalid email or password" });
-		}
+        if (user == null) {
+            return res.status(401).json({ error: "invalid email or password" });
+        }
 
-		if (user && (await bcrypt.compare(password, user.password))) {
-			const token = jwt.sign({ user_id: user.id, email }, process.env.SECRET, {
-				expiresIn: "1h",
-			});
+        if (user && (await bcrypt.compare(password, user.password))) {
+            const token = jwt.sign({ user_id: user.id, email }, process.env.SECRET, {
+                expiresIn: "1h",
+            });
 
-			return res.status(200).json({ auth: true, token });
-		}
+            return res.status(200).json({ auth: true, token });
+        }
 
-		return res.status(401).json({ error: "invalid credentials" });
-	} catch (err) {
-		console.error(`could not perform login: ${err}`);
-		return res.status(500).json({ error: "could not login user" });
-	}
+        return res.status(401).json({ error: "invalid credentials" });
+    } catch (err) {
+        console.error(`could not perform login: ${err}`);
+        return res.status(500).json({ error: "could not login user" });
+    }
 }
 
 async function getUsersList(req, res) {
-	const user = await User.findByPk(req.decoded.user_id, {
-		include: {
-			association: "levels",
-		},
-		where: { email: req.decoded.email },
-	});
+    const user = await User.findByPk(req.decoded.user_id, {
+        include: {
+            association: "levels",
+        },
+        where: { email: req.decoded.email },
+    });
 
-	if (!user) {
-		return res.status(401).json({ error: "invalid user" });
-	}
+    if (!user) {
+        return res.status(401).json({ error: "invalid user" });
+    }
 
-	const level = user.levels[0];
+    const level = user.levels[0];
 
-	if (level.id === privilegeTypes.admin) {
-		const allUsers = await User.findAll({ attributes: ["email", "created_at"] });
-		if (!allUsers) {
-			throw new Error("could not find all users");
-		}
+    if (level.id === privilegeTypes.admin) {
+        const allUsers = await User.findAll({ attributes: ["email", "created_at"] });
+        if (!allUsers) {
+            throw new Error("could not find all users");
+        }
 
-		return res.status(200).json(allUsers);
-	}
+        return res.status(200).json(allUsers);
+    }
 
-	return res.status(401).json({ error: "you don't have permissions to list all users" });
+    return res
+        .status(401)
+        .json({ error: "you don't have permissions to list all users" });
 }
 
 module.exports = {
-	createUser,
-	loginUser,
-	getUsersList,
+    createUser,
+    loginUser,
+    getUsersList,
 };

--- a/src/Controller/UserController.js
+++ b/src/Controller/UserController.js
@@ -68,7 +68,7 @@ async function createUser(req, res) {
 
         const section = await Section.findOne({ where: { id: newUserInfo.sectionID } });
         if (!department || !level || !section) {
-            return res.status(401).send({ error: "invalid user information provided" });
+            return res.status(400).send({ error: "invalid user information provided" });
         }
 
         const newUser = await User.create({

--- a/src/Controller/UserController.js
+++ b/src/Controller/UserController.js
@@ -92,8 +92,17 @@ async function loginUser(req, res) {
   }
 }
 
+async function adminCreateUser(levelID) {
+  if (levelID === 1) {
+    createUser();
+    return res.status(200);
+  } else {
+    res.status(400).send("Only admins can create users");
+  }
+}
+
 module.exports = {
   createUser,
   loginUser,
-  listUsers,
+  adminCreateUser,
 };

--- a/src/Controller/UserController.js
+++ b/src/Controller/UserController.js
@@ -86,7 +86,6 @@ async function createUser(req, res) {
 
         return res.status(200).send(newUser);
     } catch (error) {
-        console.error(`failed to create user: ${error}`);
         return res.status(500).json({ error: "internal error during user register" });
     }
 }
@@ -101,7 +100,7 @@ async function loginUser(req, res) {
 
         const user = await User.findOne({ where: { email: email } });
 
-        if (user == null) {
+        if (!user) {
             return res.status(401).json({ error: "invalid email or password" });
         }
 
@@ -116,7 +115,7 @@ async function loginUser(req, res) {
         return res.status(401).json({ error: "invalid credentials" });
     } catch (err) {
         console.error(`could not perform login: ${err}`);
-        return res.status(500).json({ error: "could not login user" });
+        return res.status(500).json({ error: `could not login user: ${err}` });
     }
 }
 
@@ -128,18 +127,10 @@ async function getUsersList(req, res) {
         where: { email: req.decoded.email },
     });
 
-    if (!user) {
-        return res.status(401).json({ error: "invalid user" });
-    }
-
     const level = user.levels[0];
 
     if (level.id === privilegeTypes.admin) {
         const allUsers = await User.findAll({ attributes: ["email", "created_at"] });
-        if (!allUsers) {
-            throw new Error("could not find all users");
-        }
-
         return res.status(200).json(allUsers);
     }
 

--- a/src/Controller/UserController.js
+++ b/src/Controller/UserController.js
@@ -43,8 +43,6 @@ async function createUser(req, res) {
 		// check for user permission
 		const requesterLevel = await findUserLevelByID(req);
 
-		console.log(requesterLevel);
-
 		if (requesterLevel.id != privilegeTypes.admin) {
 			return res
 				.status(401)

--- a/src/Database/index.js
+++ b/src/Database/index.js
@@ -5,34 +5,37 @@ const { Department } = require("../Model/Department");
 const { Level } = require("../Model/Level");
 const { Section } = require("../Model/Section");
 
+async function setupModels(db) {
+    User.init(db);
+    Department.init(db);
+    Level.init(db);
+    Section.init(db);
+
+    User.associate(db.models);
+    Department.associate(db.models);
+    Level.associate(db.models);
+    Section.associate(db.models);
+}
+
+async function setupSequelize(config) {
+    return new Sequelize(config);
+}
+
+async function configure(auth, db) {
+    return new Promise((resolve, reject) => {
+        auth.then(() => {
+            setupModels(db);
+            resolve(0);
+        });
+    });
+}
+
 async function initializeDatabase() {
-	const db = new Sequelize(config);
-
-	const auth = db.authenticate();
-
-	return new Promise((resolve, reject) => {
-		auth.then(
-			() => {
-				User.init(db);
-				Department.init(db);
-				Level.init(db);
-				Section.init(db);
-
-				User.associate(db.models);
-				Department.associate(db.models);
-				Level.associate(db.models);
-				Section.associate(db.models);
-
-				resolve(0);
-			},
-			(rejected) => {
-				console.error(`failed to authenticate: ${rejected}`);
-				reject(1);
-			}
-		);
-	});
+    const db = await setupSequelize(config);
+    const auth = db.authenticate();
+    return configure(auth, db);
 }
 
 module.exports = {
-	initializeDatabase,
+    initializeDatabase,
 };

--- a/src/index.js
+++ b/src/index.js
@@ -21,12 +21,12 @@ app.listen(APP_PORT);
 console.info(`Serving HTTP at: http://localhost:${APP_PORT}`);
 
 initializeDatabase().then(
-	() => {
-		console.info(`connected to database`);
-	},
-	() => {
-		console.error(`could not connect to database`);
-	}
+    () => {
+        console.info(`connected to database`);
+    },
+    () => {
+        console.error(`could not connect to database`);
+    }
 );
 
 module.exports = app;

--- a/src/routes.js
+++ b/src/routes.js
@@ -6,5 +6,6 @@ const router = express.Router();
 
 router.post("/register", UserController.createUser);
 router.post("/login", verifyJWT, UserController.loginUser);
+router.post("/admin", UserController.adminCreateUser);
 
 module.exports = router;

--- a/src/routes.js
+++ b/src/routes.js
@@ -4,7 +4,7 @@ const jwt = require("./Utils/JWT");
 
 const router = express.Router();
 
-router.post("/register", UserController.createUser);
+router.post("/register", jwt.verifyJWT, UserController.createUser);
 router.post("/login", UserController.loginUser);
 router.post("/users/all", jwt.verifyJWT, UserController.getUsersList);
 

--- a/tests/create-admin.js
+++ b/tests/create-admin.js
@@ -1,0 +1,133 @@
+const { User } = require("../src/Model/User");
+const { Department } = require("../src/Model/Department");
+const { Level } = require("../src/Model/Level");
+const { Section } = require("../src/Model/Section");
+const { Sequelize } = require("sequelize");
+const { hashPassword } = require("../src/Utils/hash");
+require("dotenv").config();
+
+const adminUser = {
+    email: "admin@email.com",
+    password: "admin1234",
+    departmentID: 1,
+    level: 1,
+    sectionID: 2,
+};
+
+function getDatabaseConfig() {
+    const { DB_USER, DB_PASS, DB_HOST, DB_PORT, DB_NAME } = process.env;
+    process.env.DB_HOST = "localhost";
+
+    console.log(`environment: ${DB_HOST},${DB_PASS},${DB_NAME},${DB_PORT},${DB_USER}`);
+
+    const config = {
+        username: `${DB_USER}`,
+        password: `${DB_PASS}`,
+        database: `${DB_NAME}`,
+        port: `${DB_PORT}`,
+        dialect: "postgres",
+        host: `${DB_HOST}`,
+        define: {
+            timestamps: true,
+            underscored: true,
+        },
+        logging: false,
+    };
+
+    console.log(`config: ${JSON.stringify(config)}`);
+
+    return config;
+}
+
+async function setupSequelize(config) {
+    return new Sequelize(config);
+}
+
+async function configure(auth, db) {
+    return new Promise((resolve) => {
+        auth.then(() => {
+            setupModels(db);
+            resolve(0);
+        });
+    });
+}
+
+async function initializeDatabaseWithConfig(cfg) {
+    const db = await setupSequelize(cfg);
+    const auth = db.authenticate();
+    return configure(auth, db);
+}
+
+async function setupModels(db) {
+    User.init(db);
+    Department.init(db);
+    Level.init(db);
+    Section.init(db);
+
+    User.associate(db.models);
+    Department.associate(db.models);
+    Level.associate(db.models);
+    Section.associate(db.models);
+}
+
+async function createAdminUser() {
+    try {
+        await initializeDatabaseWithConfig(getDatabaseConfig());
+        console.log("admin user created");
+    } catch (err) {
+        console.error(`could not connect to database: ${err}`);
+    }
+
+    console.log("connected to database");
+
+    const department = await Department.findOne({
+        where: { id: adminUser.departmentID },
+    });
+
+    const level = await Level.findOne({
+        where: { id: adminUser.level },
+    });
+
+    const section = await Section.findOne({
+        where: { id: adminUser.sectionID },
+    });
+
+    if (!department || !level || !section) {
+        console.error(`invalid information: ${department}, ${level}, ${section}`);
+        process.exit(1);
+    }
+
+    try {
+        const newUser = await User.create({
+            email: adminUser.email,
+            password: await hashPassword(adminUser.password),
+        });
+
+        if (!newUser) {
+            console.error("failed to create user");
+            return;
+        }
+
+        await newUser.addDepartment(department);
+        await newUser.addLevel(level);
+        await newUser.addSection(section);
+
+        console.log(`created user: ${JSON.stringify(newUser)}`);
+    } catch (err) {
+        console.log(`could not create user: ${err}`);
+    }
+}
+
+try {
+    createAdminUser().then(
+        () => {
+            process.exit(0);
+        },
+        () => {
+            process.exit(1);
+        }
+    );
+} catch (err) {
+    console.error(`error: ${err}`);
+    process.exit(1);
+}

--- a/tests/index.test.js
+++ b/tests/index.test.js
@@ -6,201 +6,203 @@ const express = require("express");
 const jwt = require("jsonwebtoken");
 
 describe("Main test", () => {
-	const newRoutes = express.Router();
-	newRoutes.post("/test", verifyJWT);
-	app.use(newRoutes);
+    const newRoutes = express.Router();
+    newRoutes.post("/test", verifyJWT);
+    app.use(newRoutes);
 
-	const token = jwt.sign({ name: "Teste", description: "Teste" }, process.env.SECRET, {
-		expiresIn: 240,
-	});
+    const userInvalidInformation = {
+        email: "blabla@hotmail.com",
+        password: "password",
+        departmentID: -1,
+        level: 100,
+        sectionID: 3,
+    };
 
-	const userInvalidInformation = {
-		email: "blabla@hotmail.com",
-		password: "password",
-		departmentID: -1,
-		level: 100,
-		sectionID: 3,
-	};
+    const user = {
+        email: "useroraculo@email.com",
+        password: "oraculo123",
+        departmentID: 3,
+        level: 2,
+        sectionID: 3,
+    };
 
-	const user = {
-		email: "useroraculo@email.com",
-		password: "oraculo123",
-		departmentID: 3,
-		level: 2,
-		sectionID: 3,
-	};
+    const user1 = {
+        email: "useroraculo1@email.com",
+        password: "oraculo12345",
+        departmentID: 3,
+        level: 2,
+        sectionID: 3,
+    };
 
-	const user1 = {
-		email: "useroraculo1@email.com",
-		password: "oraculo12345",
-		departmentID: 3,
-		level: 2,
-		sectionID: 3,
-	};
+    const adminUser = {
+        email: "admin@email.com",
+        password: "admin1234",
+        departmentID: 1,
+        level: 1,
+        sectionID: 2,
+    };
 
-	const adminUser = {
-		email: "admin@email.com",
-		password: "admin1234",
-		departmentID: 1,
-		level: 1,
-		sectionID: 2,
-	};
+    const adminToken = jwt.sign({ user_id: 1, email: user.email }, process.env.SECRET, {
+        expiresIn: "5m",
+    });
 
-	beforeAll(async () => {
-		await initializeDatabase();
-		await request(app).post("/register").send(user);
-		return;
-	});
+    beforeAll(async () => {
+        await initializeDatabase();
+        await request(app).post("/register").set("x-access-token", adminToken).send(user);
+        return;
+    });
 
-	it("Test express server app", (done) => {
-		expect(app).toBeDefined();
-		done();
-		return;
-	});
+    it("Test express server app", (done) => {
+        expect(app).toBeDefined();
+        done();
+        return;
+    });
 
-	it("POST /register - create user with a invalid department", async () => {
-		const res = await request(app).post("/register").send(userInvalidInformation);
-		expect(res.statusCode).toEqual(401);
-	});
+    it("POST /register - create user with a invalid department", async () => {
+        const res = await request(app).post("/register").send(userInvalidInformation);
+        expect(res.statusCode).toEqual(401);
+    });
 
-	it("POST /register - should not create because user already exists", async () => {
-		const res = await request(app).post("/register").send(user);
-		expect(res.statusCode).toEqual(400);
-		return res;
-	});
+    it("POST /register - should not create because user already exists", async () => {
+        const res = await request(app).post("/register").send(user);
+        expect(res.statusCode).toEqual(400);
+        return res;
+    });
 
-	it("POST /register - without all needed fields", async () => {
-		const incompleteUser = {
-			email: "tester@email.com",
-		};
+    it("POST /register - without all needed fields", async () => {
+        const incompleteUser = {
+            email: "tester@email.com",
+        };
 
-		const res = await request(app).post("/register").send(incompleteUser);
-		expect(res.statusCode).toEqual(400);
-		return res;
-	});
+        const res = await request(app).post("/register").send(incompleteUser);
+        expect(res.statusCode).toEqual(400);
+        return res;
+    });
 
-	it("POST /register - create a new user", async () => {
-		const res = await request(app).post("/register").send(user1);
-		expect(res.statusCode).toEqual(200);
-	});
+    it("POST /register - create a new user", async () => {
+        const res = await request(app).post("/register").send(user1);
+        expect(res.statusCode).toEqual(200);
+    });
 
-	it("POST /register - create admin user", async () => {
-		const res = await request(app).post("/register").send(adminUser);
-		expect(res.statusCode).toEqual(200);
-	});
+    it("POST /register - create admin user", async () => {
+        const res = await request(app).post("/register").send(adminUser);
+        expect(res.statusCode).toEqual(200);
+    });
 
-	it("POST /login - should login", async () => {
-		const res = await request(app)
-			.post("/login")
-			.send({ email: user.email, password: user.password });
+    it("POST /login - should login", async () => {
+        const res = await request(app)
+            .post("/login")
+            .send({ email: user.email, password: user.password });
 
-		expect(res.statusCode).toBe(200);
-		return res;
-	});
+        expect(res.statusCode).toBe(200);
+        return res;
+    });
 
-	it("POST /login - inexistent user", async () => {
-		const res = await request(app)
-			.post("/login")
-			.send({ email: "user@gmail.com", password: "12345" });
+    it("POST /login - inexistent user", async () => {
+        const res = await request(app)
+            .post("/login")
+            .send({ email: "user@gmail.com", password: "12345" });
 
-		expect(res.statusCode).toBe(401);
-		return res;
-	});
+        expect(res.statusCode).toBe(401);
+        return res;
+    });
 
-	it("POST /login - should not login (invalid credentials)", async () => {
-		const res = await request(app)
-			.post("/login")
-			.send({ email: user.email, password: "wrongpassword" });
+    it("POST /login - should not login (invalid credentials)", async () => {
+        const res = await request(app)
+            .post("/login")
+            .send({ email: user.email, password: "wrongpassword" });
 
-		expect(res.statusCode).toBe(401);
-		return res;
-	});
+        expect(res.statusCode).toBe(401);
+        return res;
+    });
 
-	it("POST /login - without password field", async () => {
-		const res = await request(app).post("/login").send({ email: user.email });
-		expect(res.statusCode).toBe(400);
-		return;
-	});
+    it("POST /login - without password field", async () => {
+        const res = await request(app).post("/login").send({ email: user.email });
+        expect(res.statusCode).toBe(400);
+        return;
+    });
 
-	it("POST /login - invalid field type", async () => {
-		const res = await request(app).post("/login").send({});
-		expect(res.statusCode).toBe(400);
-		return;
-	});
+    it("POST /login - invalid field type", async () => {
+        const res = await request(app).post("/login").send({});
+        expect(res.statusCode).toBe(400);
+        return;
+    });
 
-	it("POST /test - post without token", async () => {
-		const res = await request(app).post("/test");
-		expect(res.statusCode).toBe(401);
-	});
+    it("POST /test - post without token", async () => {
+        const res = await request(app).post("/test");
+        expect(res.statusCode).toBe(401);
+    });
 
-	it("POST /test - post with token", async () => {
-		const res = await request(app).post("/test").set("x-access-token", token);
-		expect(res.statusCode).toBe(404);
-	});
+    it("POST /test - post with token", async () => {
+        const res = await request(app).post("/test").set("x-access-token", token);
+        expect(res.statusCode).toBe(404);
+    });
 
-	it("POST /users/all - should not retrieve users list", async () => {
-		const res = await request(app).post("/users/all");
-		expect(res.statusCode).toEqual(401);
-	});
+    it("POST /users/all - should not retrieve users list", async () => {
+        const res = await request(app).post("/users/all");
+        expect(res.statusCode).toEqual(401);
+    });
 
-	it("POST /users/all - post without valid token", async () => {
-		const res = await request(app).post("/users/all").set("x-access-token", "invalid");
-		expect(res.statusCode).toEqual(500);
-	});
+    it("POST /users/all - post without valid token", async () => {
+        const res = await request(app)
+            .post("/users/all")
+            .set("x-access-token", "invalid");
+        expect(res.statusCode).toEqual(500);
+    });
 
-	it("POST /users/all - post without token", async () => {
-		const res = await request(app).post("/users/all");
-		expect(res.statusCode).toEqual(401);
-	});
+    it("POST /users/all - post without token", async () => {
+        const res = await request(app).post("/users/all");
+        expect(res.statusCode).toEqual(401);
+    });
 
-	it("POST /users/all - should retrieve users list", async () => {
-		// login first
-		const res = await request(app).post("/login").send({
-			email: adminUser.email,
-			password: adminUser.password,
-		});
+    it("POST /users/all - should retrieve users list", async () => {
+        // login first
+        const res = await request(app).post("/login").send({
+            email: adminUser.email,
+            password: adminUser.password,
+        });
 
-		// list users
-		const res1 = await request(app)
-			.post("/users/all")
-			.set("x-access-token", res.body.token)
-			.send();
+        // list users
+        const res1 = await request(app)
+            .post("/users/all")
+            .set("x-access-token", res.body.token)
+            .send();
 
-		expect(res1.statusCode).toEqual(200);
-	});
+        expect(res1.statusCode).toEqual(200);
+    });
 
-	it("POST /users/all - test with a less privileged user", async () => {
-		const res = await request(app).post("/login").send({
-			email: user.email,
-			password: user.password,
-		});
+    it("POST /users/all - test with a less privileged user", async () => {
+        const res = await request(app).post("/login").send({
+            email: user.email,
+            password: user.password,
+        });
 
-		const res1 = await request(app)
-			.post("/users/all")
-			.set("x-access-token", res.body.token)
-			.send();
+        const res1 = await request(app)
+            .post("/users/all")
+            .set("x-access-token", res.body.token)
+            .send();
 
-		expect(res1.statusCode).toEqual(401);
-	});
+        expect(res1.statusCode).toEqual(401);
+    });
 
-	it("POST /users/all - test with invalid decoded information", async () => {
-		const res = await request(app).post("/login").send({
-			email: user.email,
-			password: user.password,
-		});
+    it("POST /users/all - test with invalid decoded information", async () => {
+        const res = await request(app).post("/login").send({
+            email: user.email,
+            password: user.password,
+        });
 
-		console.log(res.body);
-		expect(res.statusCode).toEqual(200);
+        console.log(res.body);
+        expect(res.statusCode).toEqual(200);
 
-		const res1 = await request(app)
-			.post("/users/all")
-			.set("x-access-token", "my_invalid_token_123")
-			.send();
+        const res1 = await request(app)
+            .post("/users/all")
+            .set("x-access-token", "my_invalid_token_123")
+            .send();
 
-		expect(res1.statusCode).toEqual(500);
-	});
+        expect(res1.statusCode).toEqual(500);
+    });
 });
 
 afterAll((done) => {
-	done();
+    done();
 });

--- a/tests/index.test.js
+++ b/tests/index.test.js
@@ -2,6 +2,7 @@ const app = require("../src");
 const request = require("supertest");
 const db = require("../src/Database");
 const { listUsers } = require("../src/Controller/UserController");
+const { describe } = require("../src/Model/User");
 
 const user = {
   email: `${Math.random().toString(36).substr(2, 5)}@gmail.com`,
@@ -38,6 +39,13 @@ describe("Test register user", () => {
     expect(res.body.level).toBe(user.level);
     expect(res.body.sectionID).toBe(user.sectionID);
   });
+});
+
+describe("Test admin create user", () => {
+  it("POST /admin", async () => {
+    const rest = await request(app).post("/admin");
+    expect(res.statusCode).toEqual(200);
+  })
 });
 
 describe("Test database client setup", () => {


### PR DESCRIPTION
**Issue** closes fga-eps-mds/2021.1-Oraculo#40

## Descrição
- adição de endpoint para criar usuário
  - apenas administradores podem criar, utilizando um token JWT
- adição de ferramenta para fazer o pré-cadastro de usuário com privilégios administrativos diretamente no banco
- correção nos testes unitários, pois agora eles exigem um pré-cadastro de usuário com permissões de admin no banco de dados
- mudança em alguns códigos de resposta HTTP retornados pelo servidor